### PR TITLE
fix Dockerfile - missing \

### DIFF
--- a/config/docker/Dockerfile
+++ b/config/docker/Dockerfile
@@ -18,7 +18,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install apt-transport-https apt-utils && \
     apt-get -y install libterm-readline-gnu-perl software-properties-common && \
-    add-apt-repository -y ppa:gift/$PPA_TRACK && apt-get -y update &&
+    add-apt-repository -y ppa:gift/$PPA_TRACK && apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y install locales plaso-tools && \
     apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*


### PR DESCRIPTION
## One line description of pull request

Dockerfile is missing a \ at the of a line

## Description:


**Related issue (if applicable):** fixes #<plaso issue number here>

## Notes:
All contributions to Plaso undergo [code
review](https://github.com/log2timeline/l2tdocs/blob/main/process/Code%20review%20process.asciidoc). This makes sure
that the code has appropriate test coverage and conforms to the Plaso [style
guide](https://plaso.readthedocs.io/en/latest/sources/developer/Style-guide.html).

One of the maintainers will examine your code, and may request changes. Check off the items below in
order, and then a maintainer will review your code.

## Checklist:
  - [ ] Automated checks (Travis, Codecov, Codefactor )pass
  - [ ] No new [new dependencies](https://plaso.readthedocs.io/en/latest/sources/developer/Adding-a-new-dependency.html) are required or l2tdevtools has been updated
  - [ ] Reviewer assigned
